### PR TITLE
support emscripten-1.38.31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all: dav1d.wasm
 patch:
 	patch -d dav1d -p1 <dav1d.patch
 
-build/dist/lib64/libdav1d.a:
-	meson dav1d build \
+build/dist/lib/libdav1d.a:
+	meson setup \
 		--prefix="$(CURDIR)/build/dist" \
 		--cross-file=cross_file.txt \
 		--default-library=static \
@@ -14,16 +14,17 @@ build/dist/lib64/libdav1d.a:
 		-Dbuild_tools=false \
 		-Dbuild_tests=false \
 		-Dlogging=false \
-	&& ninja -C build install
+		./dav1d ./build \
+	&& ninja -C ./build install
 
-dav1d.wasm: build/dist/lib64/libdav1d.a dav1d.c
-	emcc $^ -DNDEBUG -O3 --llvm-lto 3 -Ibuild/dist/include -o $@ \
+dav1d.wasm: dav1d.c build/dist/lib/libdav1d.a
+	emcc $^ -DNDEBUG -Os --llvm-lto 3 -Ibuild/dist/include -o $@ \
 		-s TOTAL_MEMORY=67108864 -s MALLOC=emmalloc
 
 .PHONY: test
 test: dav1d.c
 	$(CC) $^ $(CFLAGS) -O2 -Wall -o $@ \
-		-I../tmp/dav1d/dist/include -L../tmp/dav1d/dist/lib64 \
+		-I../tmp/dav1d/dist/include -L../tmp/dav1d/dist/lib \
 		-ldav1d -lpthread
 
 test-native: test

--- a/dav1d.js
+++ b/dav1d.js
@@ -1,13 +1,21 @@
 // Must be in sync with emcc settings!
+
 const TOTAL_MEMORY = 64 * 1024 * 1024; // TODO(Kagami): Find optimal amount
-const TOTAL_STACK = 5626096; // TODO(Kagami): Find why bigger than 5MB
+const DYNAMICTOP_PTR = 385392;
+const DYNAMIC_BASE = 5628304;
+// const TOTAL_STACK = 5242880; // TODO(Kagami): Find why bigger than 5MB
 const PAGE_SIZE = 64 * 1024;
-const TABLE_SIZE = 271; // NOTE(Kagami): Depends on the number of
+const TABLE_SIZE = 414; // NOTE(Kagami, ledyba-z): Depends on the number of
                         // function pointers in target library, seems
                         // like no way to know in general case
 
+function abort(what) {
+  throw "abort(" + what + "). Build with -s ASSERTIONS=1 for more info.";
+}
+
+var wasmModule;
+
 function getRuntime() {
-  let dynamicTop = TOTAL_STACK;
   const table = new WebAssembly.Table({
     initial: TABLE_SIZE,
     maximum: TABLE_SIZE,
@@ -18,25 +26,46 @@ function getRuntime() {
     maximum: TOTAL_MEMORY / PAGE_SIZE,
   });
   const HEAPU8 = new Uint8Array(memory.buffer);
+  const HEAPU32 = new Uint32Array(memory.buffer);
+  HEAPU32[DYNAMICTOP_PTR >> 2] = DYNAMIC_BASE;
+
   return {
     table: table,
     memory: memory,
-    sbrk: (increment) => {
-      const oldDynamicTop = dynamicTop;
-      dynamicTop += increment;
-      return oldDynamicTop;
-    },
-    emscripten_memcpy_big: (dest, src, num) => {
+    __table_base: 0,
+    __memory_base: 1024,
+    DYNAMICTOP_PTR: DYNAMICTOP_PTR,
+    _emscripten_memcpy_big: (dest, src, num) => {
       HEAPU8.set(HEAPU8.subarray(src, src+num), dest);
     },
+    _emscripten_resize_heap: (requestedSize) => {
+      abort('OOM');
+    },
+    _emscripten_get_heap_size: () => {
+      return memory.buffer.byteLength;
+    },
     // Empty stubs for dav1d.
-    pthread_cond_wait: (cond, mutex) => 0,
-    pthread_cond_signal: (cond) => 0,
-    pthread_cond_destroy: (cond) => 0,
-    pthread_cond_init: (cond, attr) => 0,
-    pthread_cond_broadcast: (cond) => 0,
-    pthread_join: (thread, res) => 0,
-    pthread_create: (thread, attr, func, arg) => 0,
+    _pthread_cond_wait: (cond, mutex) => 0,
+    _pthread_cond_signal: (cond) => 0,
+    _pthread_cond_destroy: (cond) => 0,
+    _pthread_cond_destroy: (cond) => 0,
+    _pthread_cond_init: (cond, attr) => 0,
+    _pthread_cond_broadcast: (cond) => 0,
+    _pthread_join: (thread, res) => 0,
+    _pthread_create: (thread, attr, func, arg) => 0,
+    _pthread_attr_init: (attr) => 0,
+    _pthread_attr_destroy: (attr) => 0,
+    _pthread_attr_setstacksize: (attr, stacksize) => 0,
+    _abort: abort,
+    abort: abort,
+    ___setErrNo: (value) => {
+      HEAPU32[wasmModule["___errno_location"]() >> 2] = value
+    },
+    ___syscall6: () => { abort('syscall6'); },
+    ___syscall140: () => { abort('syscall140'); },
+    ___syscall146: () => { abort('syscall146'); },
+    abortOnCannotGrowMemory: (requestedSize) => { abort('OOM'); },
+    
     // Emscripten debug.
     // abort: () => {},
     // __lock: () => {},
@@ -62,8 +91,11 @@ export function create(opts = {}) {
     return Promise.reject(new Error("Either wasmURL or wasmData shall be provided"));
   }
   const runtime = getRuntime();
-  const imports = {env: runtime};
+  const imports = {
+    env: runtime,
+  };
   return fetchAndInstantiate(opts.wasmData, opts.wasmURL, imports).then(wasm => {
+    wasmModule = wasm.exports;
     const d = new Dav1d({wasm, runtime});
     d._init();
     return d;
@@ -84,17 +116,17 @@ class Dav1d {
     this.lastFrameRef = 0;
   }
   _init() {
-    this.ref = this.FFI.djs_init();
+    this.ref = this.FFI._djs_init();
     if (!this.ref) throw new Error("error in djs_init");
   }
   _decodeFrame(obu, format, unsafe) {
     if (!ArrayBuffer.isView(obu)) {
       obu = new Uint8Array(obu);
     }
-    const obuRef = this.FFI.djs_alloc_obu(obu.byteLength);
+    const obuRef = this.FFI._djs_alloc_obu(obu.byteLength);
     if (!obuRef) throw new Error("error in djs_alloc_obu");
     this.HEAPU8.set(obu, obuRef);
-    const frameRef = this.FFI.djs_decode_obu(this.ref, obuRef, obu.byteLength, format);
+    const frameRef = this.FFI._djs_decode_obu(this.ref, obuRef, obu.byteLength, format);
     if (!frameRef) throw new Error("error in djs_decode");
     const frameInfo = new Uint32Array(this.buffer, frameRef, 4);
     const width = frameInfo[0];
@@ -108,7 +140,7 @@ class Dav1d {
     }
     const data = new Uint8Array(size);
     data.set(srcData);
-    this.FFI.djs_free_frame(frameRef);
+    this.FFI._djs_free_frame(frameRef);
     return {width, height, data};
   }
 
@@ -138,7 +170,7 @@ class Dav1d {
   }
   unsafeCleanup() {
     if (this.lastFrameRef) {
-      this.FFI.djs_free_frame(this.lastFrameRef);
+      this.FFI._djs_free_frame(this.lastFrameRef);
       this.lastFrameRef = 0;
     }
   }


### PR DESCRIPTION
Hello!

Today I built dav1d.js with emcc 1.38.31.

Some changes are need to buid, so I will send the patch as a pull request.

Please take a look.

here is a version I used to build:
```
% emcc --version
emcc (Emscripten gcc/clang-like replacement) 1.38.31 (commit 5b75fb38da4732a32585320e0997953ede9e4ac5)
Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
This is free and open source software under the MIT license.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

% meson --version
0.50.1
```

FYI: I also tried emcc 1.39.3, the latest version, but I gave up. To build in 1.39.x, it looks we need to make many additional efforts to support [standalone mode](https://github.com/emscripten-core/emscripten/wiki/WebAssembly-Standalone).
