### PR TITLE
Fix wrong out stride in fill_bmp_data_from_420

### DIFF
--- a/dav1d.c
+++ b/dav1d.c
@@ -116,11 +116,12 @@ static void fill_bmp_data_from_420(const Dav1dPicture *pic, uint8_t *output, int
   int strideY = pic->stride[0];
   int strideCb = pic->stride[1];
   int strideCr = pic->stride[1];
-  int outPtr0 = 0;
-  int outPtr1 = outStride;
   int ydec = 0;
 
   for (int y = 0; y < height; y += 2) {
+    int outPtr0 = y * outStride;
+    int outPtr1 = outPtr0 + outStride;
+
     int Y0Ptr = y * strideY;
     int Y1Ptr = Y0Ptr + strideY;
     int CbPtr = ydec * strideCb;
@@ -157,8 +158,6 @@ static void fill_bmp_data_from_420(const Dav1dPicture *pic, uint8_t *output, int
       output[outPtr1 + 2] = clamp((multY + multCrR) >> 8);
       outPtr1 += 3;
     }
-    outPtr0 += outStride;
-    outPtr1 += outStride;
     ydec++;
   }
 }


### PR DESCRIPTION
Hi.

In original source, decoded images are glitched if `outStride != width * 3`.
(This occurs if the width is not a multiple of 4, because of the limitation of the bmp format)

Here is a decoding result of an image, which is 3082(w)x2048(h):

<img width="1113" alt="スクリーンショット 2019-12-01 10 43 34" src="https://user-images.githubusercontent.com/51456946/69908776-5a5aa900-1433-11ea-94b7-c6079b9ae4ae.png">

In this patch, I fixed this glitch. Result:

<img width="1115" alt="スクリーンショット 2019-12-01 10 44 51" src="https://user-images.githubusercontent.com/51456946/69908782-6e9ea600-1433-11ea-86ff-6afb430969a7.png">

Please take a look!